### PR TITLE
Allow nested rtxn from wtxn

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3413,6 +3413,7 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 
 		txn->mt_numdbs = 0;
 		txn->mt_flags = MDB_TXN_FINISHED;
+		mdb_midl_free(txn->mt_spill_pgs);
 
 		if (!txn->mt_parent) {
 			mdb_midl_shrink(&txn->mt_free_pgs);
@@ -3434,7 +3435,6 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			mdb_midl_free(txn->mt_free_pgs);
 			free(txn->mt_u.dirty_list);
 		}
-		mdb_midl_free(txn->mt_spill_pgs);
 
 		mdb_midl_free(pghead);
 	}

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -9628,7 +9628,7 @@ mdb_cursor_del0(MDB_cursor *mc)
 						goto fail;
 				}
 				if (m3->mc_xcursor && !(m3->mc_flags & C_EOF)) {
-					MDB_node *node = NODEPTR(m3->mc_pg[m3->mc_top], m3->mc_ki[m3->mc_top]);
+					MDB_node *node = NODEPTR(m3->mc_pg[mc->mc_top], m3->mc_ki[mc->mc_top]);
 					/* If this node has dupdata, it may need to be reinited
 					 * because its data has moved.
 					 * If the xcursor was not initd it must be reinited.

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -137,6 +137,7 @@ static NtCloseFunc *NtClose;
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <stdatomic.h>
 
 #ifdef _MSC_VER
 #include <io.h>
@@ -1302,6 +1303,8 @@ struct MDB_txn {
 	MDB_txn		*mt_parent;		/**< parent of a nested txn */
 	/** Nested txn under this txn, set together with flag #MDB_TXN_HAS_CHILD */
 	MDB_txn		*mt_child;
+	/** The count of nested RDONLY txns under this txn also named child txns */
+	atomic_uint	mt_rdonly_child_count;
 	pgno_t		mt_next_pgno;	/**< next unallocated page */
 #ifdef MDB_VL32
 	pgno_t		mt_last_pgno;	/**< last written page */
@@ -3144,6 +3147,7 @@ mdb_txn_renew0(MDB_txn *txn)
 			mdb_debug = MDB_DBG_INFO;
 #endif
 		txn->mt_child = NULL;
+		txn->mt_rdonly_child_count = 0;
 		txn->mt_loose_pgs = NULL;
 		txn->mt_loose_count = 0;
 		txn->mt_dirty_room = MDB_IDL_UM_MAX;
@@ -3212,6 +3216,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 	MDB_txn *txn;
 	MDB_ntxn *ntxn;
 	int rc, size, tsize;
+	int is_nested_rdonly = 0;
 
 	flags &= MDB_TXN_BEGIN_FLAGS;
 	flags |= env->me_flags & MDB_WRITEMAP;
@@ -3220,8 +3225,13 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		return EACCES;
 
 	if (parent) {
+		// We remove the RDONLY flag but still keep track of it
+		// TODO Remove this and make that better integrated
+		is_nested_rdonly = flags | MDB_RDONLY;
+		flags &= ~MDB_RDONLY;
 		/* Nested transactions: Max 1 child, write txns only, no writemap */
 		flags |= parent->mt_flags;
+		// TODO disallow when mt_rdonly_child_count > 0
 		if (flags & (MDB_RDONLY|MDB_WRITEMAP|MDB_TXN_BLOCKED)) {
 			return (parent->mt_flags & MDB_TXN_RDONLY) ? EINVAL : MDB_BAD_TXN;
 		}
@@ -3276,8 +3286,14 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		txn->mt_u.dirty_list[0].mid = 0;
 		txn->mt_spill_pgs = NULL;
 		txn->mt_next_pgno = parent->mt_next_pgno;
-		parent->mt_flags |= MDB_TXN_HAS_CHILD;
-		parent->mt_child = txn;
+		if (is_nested_rdonly != 0) {
+			parent->mt_child = NULL;
+			atomic_fetch_add(&parent->mt_rdonly_child_count, 1);
+		} else {
+			parent->mt_flags |= MDB_TXN_HAS_CHILD;
+			parent->mt_child = txn;
+			parent->mt_rdonly_child_count = 0;
+		}
 		txn->mt_parent = parent;
 		txn->mt_numdbs = parent->mt_numdbs;
 #ifdef MDB_VL32
@@ -3377,6 +3393,7 @@ static void
 mdb_txn_end(MDB_txn *txn, unsigned mode)
 {
 	MDB_env	*env = txn->mt_env;
+	int iamtheone = 0;
 #if MDB_DEBUG
 	static const char *const names[] = MDB_END_NAMES;
 #endif
@@ -3429,14 +3446,20 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			if (env->me_txns)
 				UNLOCK_MUTEX(env->me_wmutex);
 		} else {
-			txn->mt_parent->mt_child = NULL;
-			txn->mt_parent->mt_flags &= ~MDB_TXN_HAS_CHILD;
-			env->me_pgstate = ((MDB_ntxn *)txn)->mnt_pgstate;
+			if (F_ISSET(txn->mt_parent->mt_flags, MDB_TXN_HAS_CHILD) ||
+				(iamtheone = atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1) == 1))
+			{
+				txn->mt_parent->mt_child = NULL;
+				txn->mt_parent->mt_flags &= ~MDB_TXN_HAS_CHILD;
+				env->me_pgstate = ((MDB_ntxn *)txn)->mnt_pgstate;
+			}
 			mdb_midl_free(txn->mt_free_pgs);
 			free(txn->mt_u.dirty_list);
 		}
 
-		mdb_midl_free(pghead);
+		if (!txn->mt_parent || (txn->mt_parent && iamtheone)) {
+			mdb_midl_free(pghead);
+		}
 	}
 #ifdef MDB_VL32
 	if (!txn->mt_parent) {
@@ -3485,6 +3508,9 @@ _mdb_txn_abort(MDB_txn *txn)
 {
 	if (txn == NULL)
 		return;
+
+	// You must first abort the child before the parent
+	mdb_tassert(txn, atomic_load(&txn->mt_rdonly_child_count) == 0);
 
 	if (txn->mt_child)
 		_mdb_txn_abort(txn->mt_child);

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -6508,7 +6508,7 @@ mdb_page_get(MDB_cursor *mc, pgno_t pgno, MDB_page **ret, int *lvl)
 	MDB_page *p = NULL;
 	int level;
 
-	if (! (mc->mc_flags & (C_ORIG_RDONLY|C_WRITEMAP))) {
+	if (! (( mc->mc_flags & (C_ORIG_RDONLY|C_WRITEMAP) ) && mc->mc_txn->mt_parent == NULL)) {
 		MDB_txn *tx2 = txn;
 		level = 1;
 		do {

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3394,7 +3394,7 @@ static void
 mdb_txn_end(MDB_txn *txn, unsigned mode)
 {
 	MDB_env	*env = txn->mt_env;
-	uint flags = txn->mt_flags;
+	unsigned int flags = txn->mt_flags;
 #if MDB_DEBUG
 	static const char *const names[] = MDB_END_NAMES;
 #endif

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3225,17 +3225,14 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 
 	if (parent) {
 		/* Nested transactions:
-		 * If RDONLY: Any number of child, writemap allowed
+		 * If RDONLY: Any number of children, writemap allowed
 		 * If write: Max 1 child, no writemap
 		 */
 		flags |= parent->mt_flags;
-		if (parent->mt_child && parent->mt_child->mt_flags & MDB_RDONLY && flags & MDB_RDONLY) {
-			flags &= ~MDB_TXN_BLOCKED;
+		if (parent->mt_child && F_ISSET(parent->mt_child->mt_flags, MDB_RDONLY) && F_ISSET(flags, MDB_RDONLY)) {
+			flags &= ~MDB_TXN_HAS_CHILD;
 		}
-		// TODO disallow when mt_rdonly_child_count > 0
-		if ((flags & MDB_WRITEMAP && !(flags & MDB_RDONLY))
-		|| (flags & MDB_TXN_BLOCKED && !(parent->mt_child && parent->mt_child->mt_flags & MDB_RDONLY)))
-		{
+		if ((F_ISSET(flags, MDB_WRITEMAP) && !F_ISSET(flags, MDB_RDONLY)) || F_ISSET(flags, MDB_TXN_BLOCKED)) {
 			return (parent->mt_flags & MDB_TXN_RDONLY) ? EINVAL : MDB_BAD_TXN;
 		}
 		/* Child txns save MDB_pgstate and use own copy of cursors */
@@ -3450,9 +3447,7 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			if (env->me_txns)
 				UNLOCK_MUTEX(env->me_wmutex);
 		} else {
-			if (F_ISSET(txn->mt_parent->mt_flags, MDB_TXN_HAS_CHILD)
-			|| atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1) == 1)
-			{
+			if (!F_ISSET(flags, MDB_RDONLY) || atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1) == 1) {
 				txn->mt_parent->mt_child = NULL;
 				txn->mt_parent->mt_flags &= ~MDB_TXN_HAS_CHILD;
 				env->me_pgstate = ((MDB_ntxn *)txn)->mnt_pgstate;

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3232,7 +3232,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		/* Nested transactions: Max 1 child, write txns only, no writemap */
 		flags |= parent->mt_flags;
 		// TODO disallow when mt_rdonly_child_count > 0
-		if (flags & (MDB_RDONLY|MDB_WRITEMAP|MDB_TXN_BLOCKED)) {
+		if ((flags & MDB_WRITEMAP && is_nested_rdonly == 0) || flags & MDB_TXN_BLOCKED) {
 			return (parent->mt_flags & MDB_TXN_RDONLY) ? EINVAL : MDB_BAD_TXN;
 		}
 		/* Child txns save MDB_pgstate and use own copy of cursors */

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3227,7 +3227,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 	if (parent) {
 		// We remove the RDONLY flag but still keep track of it
 		// TODO Remove this and make that better integrated
-		is_nested_rdonly = flags | MDB_RDONLY;
+		is_nested_rdonly = flags & MDB_RDONLY;
 		flags &= ~MDB_RDONLY;
 		/* Nested transactions: Max 1 child, write txns only, no writemap */
 		flags |= parent->mt_flags;
@@ -3273,6 +3273,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		unsigned int i;
 		txn->mt_cursors = (MDB_cursor **)(txn->mt_dbs + env->me_maxdbs);
 		txn->mt_dbiseqs = parent->mt_dbiseqs;
+		/* Not useful when nested RDONLY but correctly freed in mdb_txn_end */
 		txn->mt_u.dirty_list = malloc(sizeof(MDB_ID2)*MDB_IDL_UM_SIZE);
 		if (!txn->mt_u.dirty_list ||
 			!(txn->mt_free_pgs = mdb_midl_alloc(MDB_IDL_UM_MAX)))
@@ -3286,7 +3287,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		txn->mt_u.dirty_list[0].mid = 0;
 		txn->mt_spill_pgs = NULL;
 		txn->mt_next_pgno = parent->mt_next_pgno;
-		if (is_nested_rdonly != 0) {
+		if (is_nested_rdonly) {
 			parent->mt_child = NULL;
 			atomic_fetch_add(&parent->mt_rdonly_child_count, 1);
 		} else {
@@ -3306,7 +3307,8 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		rc = 0;
 		ntxn = (MDB_ntxn *)txn;
 		ntxn->mnt_pgstate = env->me_pgstate; /* save parent me_pghead & co */
-		if (env->me_pghead) {
+		/* Do not copy parent me_pghead when nested and RDONLY */
+		if (!is_nested_rdonly && env->me_pghead) {
 			size = MDB_IDL_SIZEOF(env->me_pghead);
 			env->me_pghead = mdb_midl_alloc(env->me_pghead[0]);
 			if (env->me_pghead)
@@ -3393,7 +3395,7 @@ static void
 mdb_txn_end(MDB_txn *txn, unsigned mode)
 {
 	MDB_env	*env = txn->mt_env;
-	int iamtheone = 0;
+	uint child_count = 0;
 #if MDB_DEBUG
 	static const char *const names[] = MDB_END_NAMES;
 #endif
@@ -3446,8 +3448,8 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			if (env->me_txns)
 				UNLOCK_MUTEX(env->me_wmutex);
 		} else {
-			if (F_ISSET(txn->mt_parent->mt_flags, MDB_TXN_HAS_CHILD) ||
-				(iamtheone = atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1) == 1))
+			if (F_ISSET(txn->mt_parent->mt_flags, MDB_TXN_HAS_CHILD)
+			|| (child_count = atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1)) == 1)
 			{
 				txn->mt_parent->mt_child = NULL;
 				txn->mt_parent->mt_flags &= ~MDB_TXN_HAS_CHILD;
@@ -3457,7 +3459,10 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			free(txn->mt_u.dirty_list);
 		}
 
-		if (!txn->mt_parent || (txn->mt_parent && iamtheone)) {
+		/* If you have a parent and your parent doesn't have a child
+		 * then it's a multi-nested RDONLY transaction case
+		 */
+		if (!(txn->mt_parent && !txn->mt_parent->mt_child)) {
 			mdb_midl_free(pghead);
 		}
 	}

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3289,7 +3289,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		txn->mt_next_pgno = parent->mt_next_pgno;
 		parent->mt_flags |= MDB_TXN_HAS_CHILD;
 		parent->mt_child = txn;
-		if (flags & MDB_RDONLY) {
+		if (F_ISSET(flags, MDB_RDONLY)) {
 			atomic_fetch_add(&parent->mt_rdonly_child_count, 1);
 		} else {
 			parent->mt_rdonly_child_count = 0;
@@ -3307,7 +3307,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		ntxn = (MDB_ntxn *)txn;
 		ntxn->mnt_pgstate = env->me_pgstate; /* save parent me_pghead & co */
 		/* Do not copy parent me_pghead when nested and RDONLY */
-		if (!(flags & MDB_RDONLY) && env->me_pghead) {
+		if (!F_ISSET(flags, MDB_RDONLY) && env->me_pghead) {
 			size = MDB_IDL_SIZEOF(env->me_pghead);
 			env->me_pghead = mdb_midl_alloc(env->me_pghead[0]);
 			if (env->me_pghead)
@@ -3447,6 +3447,7 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			if (env->me_txns)
 				UNLOCK_MUTEX(env->me_wmutex);
 		} else {
+			/* mark parent txn has no longer having children if this is the last nested txn */
 			if (!F_ISSET(flags, MDB_RDONLY) || atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1) == 1) {
 				txn->mt_parent->mt_child = NULL;
 				txn->mt_parent->mt_flags &= ~MDB_TXN_HAS_CHILD;
@@ -3456,8 +3457,8 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			free(txn->mt_u.dirty_list);
 		}
 
-		/* A parent and RDONLY, it's a multi-nested RDONLY transaction case */
-		if (!(txn->mt_parent && flags & MDB_RDONLY)) {
+		/* no pghead was allocated for nested RDONLY transactions */
+		if (! (txn->mt_parent && F_ISSET(flags, MDB_RDONLY))) {
 			mdb_midl_free(pghead);
 		}
 	}

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3229,8 +3229,13 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		 * If write: Max 1 child, no writemap
 		 */
 		flags |= parent->mt_flags;
+		if (parent->mt_child && parent->mt_child->mt_flags & MDB_RDONLY && flags & MDB_RDONLY) {
+			flags &= ~MDB_TXN_BLOCKED;
+		}
 		// TODO disallow when mt_rdonly_child_count > 0
-		if ((flags & MDB_WRITEMAP && !(flags & MDB_RDONLY)) || flags & MDB_TXN_BLOCKED) {
+		if ((flags & MDB_WRITEMAP && !(flags & MDB_RDONLY))
+		|| (flags & MDB_TXN_BLOCKED && !(parent->mt_child && parent->mt_child->mt_flags & MDB_RDONLY)))
+		{
 			return (parent->mt_flags & MDB_TXN_RDONLY) ? EINVAL : MDB_BAD_TXN;
 		}
 		/* Child txns save MDB_pgstate and use own copy of cursors */
@@ -3285,14 +3290,11 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		txn->mt_u.dirty_list[0].mid = 0;
 		txn->mt_spill_pgs = NULL;
 		txn->mt_next_pgno = parent->mt_next_pgno;
+		parent->mt_flags |= MDB_TXN_HAS_CHILD;
+		parent->mt_child = txn;
 		if (flags & MDB_RDONLY) {
-			// TODO set this flag again
-			// parent->mt_flags |= MDB_TXN_HAS_CHILD;
-			parent->mt_child = NULL;
 			atomic_fetch_add(&parent->mt_rdonly_child_count, 1);
 		} else {
-			parent->mt_flags |= MDB_TXN_HAS_CHILD;
-			parent->mt_child = txn;
 			parent->mt_rdonly_child_count = 0;
 		}
 		txn->mt_parent = parent;
@@ -3459,9 +3461,7 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 			free(txn->mt_u.dirty_list);
 		}
 
-		/* If you have a parent and your parent doesn't have a child
-		 * then it's a multi-nested RDONLY transaction case
-		 */
+		/* A parent and RDONLY, it's a multi-nested RDONLY transaction case */
 		if (!(txn->mt_parent && flags & MDB_RDONLY)) {
 			mdb_midl_free(pghead);
 		}

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -3216,7 +3216,6 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 	MDB_txn *txn;
 	MDB_ntxn *ntxn;
 	int rc, size, tsize;
-	int is_nested_rdonly = 0;
 
 	flags &= MDB_TXN_BEGIN_FLAGS;
 	flags |= env->me_flags & MDB_WRITEMAP;
@@ -3225,14 +3224,13 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		return EACCES;
 
 	if (parent) {
-		// We remove the RDONLY flag but still keep track of it
-		// TODO Remove this and make that better integrated
-		is_nested_rdonly = flags & MDB_RDONLY;
-		flags &= ~MDB_RDONLY;
-		/* Nested transactions: Max 1 child, write txns only, no writemap */
+		/* Nested transactions:
+		 * If RDONLY: Any number of child, writemap allowed
+		 * If write: Max 1 child, no writemap
+		 */
 		flags |= parent->mt_flags;
 		// TODO disallow when mt_rdonly_child_count > 0
-		if ((flags & MDB_WRITEMAP && is_nested_rdonly == 0) || flags & MDB_TXN_BLOCKED) {
+		if ((flags & MDB_WRITEMAP && !(flags & MDB_RDONLY)) || flags & MDB_TXN_BLOCKED) {
 			return (parent->mt_flags & MDB_TXN_RDONLY) ? EINVAL : MDB_BAD_TXN;
 		}
 		/* Child txns save MDB_pgstate and use own copy of cursors */
@@ -3287,7 +3285,9 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		txn->mt_u.dirty_list[0].mid = 0;
 		txn->mt_spill_pgs = NULL;
 		txn->mt_next_pgno = parent->mt_next_pgno;
-		if (is_nested_rdonly) {
+		if (flags & MDB_RDONLY) {
+			// TODO set this flag again
+			// parent->mt_flags |= MDB_TXN_HAS_CHILD;
 			parent->mt_child = NULL;
 			atomic_fetch_add(&parent->mt_rdonly_child_count, 1);
 		} else {
@@ -3308,7 +3308,7 @@ mdb_txn_begin(MDB_env *env, MDB_txn *parent, unsigned int flags, MDB_txn **ret)
 		ntxn = (MDB_ntxn *)txn;
 		ntxn->mnt_pgstate = env->me_pgstate; /* save parent me_pghead & co */
 		/* Do not copy parent me_pghead when nested and RDONLY */
-		if (!is_nested_rdonly && env->me_pghead) {
+		if (!(flags & MDB_RDONLY) && env->me_pghead) {
 			size = MDB_IDL_SIZEOF(env->me_pghead);
 			env->me_pghead = mdb_midl_alloc(env->me_pghead[0]);
 			if (env->me_pghead)
@@ -3395,7 +3395,7 @@ static void
 mdb_txn_end(MDB_txn *txn, unsigned mode)
 {
 	MDB_env	*env = txn->mt_env;
-	uint child_count = 0;
+	uint flags = txn->mt_flags;
 #if MDB_DEBUG
 	static const char *const names[] = MDB_END_NAMES;
 #endif
@@ -3408,7 +3408,7 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 		txn->mt_txnid, (txn->mt_flags & MDB_TXN_RDONLY) ? 'r' : 'w',
 		(void *) txn, (void *)env, txn->mt_dbs[MAIN_DBI].md_root));
 
-	if (F_ISSET(txn->mt_flags, MDB_TXN_RDONLY)) {
+	if (!txn->mt_parent && F_ISSET(txn->mt_flags, MDB_TXN_RDONLY)) {
 		if (txn->mt_u.reader) {
 			txn->mt_u.reader->mr_txnid = (txnid_t)-1;
 			if (!(env->me_flags & MDB_NOTLS)) {
@@ -3449,7 +3449,7 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 				UNLOCK_MUTEX(env->me_wmutex);
 		} else {
 			if (F_ISSET(txn->mt_parent->mt_flags, MDB_TXN_HAS_CHILD)
-			|| (child_count = atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1)) == 1)
+			|| atomic_fetch_sub(&txn->mt_parent->mt_rdonly_child_count, 1) == 1)
 			{
 				txn->mt_parent->mt_child = NULL;
 				txn->mt_parent->mt_flags &= ~MDB_TXN_HAS_CHILD;
@@ -3462,7 +3462,7 @@ mdb_txn_end(MDB_txn *txn, unsigned mode)
 		/* If you have a parent and your parent doesn't have a child
 		 * then it's a multi-nested RDONLY transaction case
 		 */
-		if (!(txn->mt_parent && !txn->mt_parent->mt_child)) {
+		if (!(txn->mt_parent && flags & MDB_RDONLY)) {
 			mdb_midl_free(pghead);
 		}
 	}
@@ -3514,8 +3514,10 @@ _mdb_txn_abort(MDB_txn *txn)
 	if (txn == NULL)
 		return;
 
-	// You must first abort the child before the parent
-	mdb_tassert(txn, atomic_load(&txn->mt_rdonly_child_count) == 0);
+	if (txn->mt_parent && txn->mt_flags & MDB_RDONLY) {
+		// You must first abort the child before the parent
+		mdb_tassert(txn, txn->mt_parent && atomic_load(&txn->mt_rdonly_child_count) == 0);
+	}
 
 	if (txn->mt_child)
 		_mdb_txn_abort(txn->mt_child);


### PR DESCRIPTION
In this PR, we updated LMDB to accept multiple nested read-only transactions. We free/close the child transactions only once the last one has been dropped. I am [proposing this patch upstream](https://bugs.openldap.org/show_bug.cgi?id=10395).

We use atomics to implement a reference-counted system that correctly drops the read transactions and the pghead only once. This is not C99 but C11-compatible.